### PR TITLE
Fix small percentage bug

### DIFF
--- a/gcodestat.c
+++ b/gcodestat.c
@@ -552,7 +552,7 @@ int main(int argc, char** argv) {
                //fprintf(output_file, "M117 %i%% Remaining ", (int) floor(next_pct * 100));
                //print_timeleft(output_file, (long int) floor(total_seconds - seconds));
                //fprintf(output_file, "\n");
-               print_timeleft_f(output_file, m117format, (long int) floor(total_seconds - seconds), (int) floor(next_pct * 100));
+               print_timeleft_f(output_file, m117format, (long int) floor(total_seconds - seconds), (int) ceill(next_pct * 100));
                next_pct -= pct_step;
             }
          }


### PR DESCRIPTION

For some values of percentage step, for example 5, you get odd values: Instead of 10, 95, 90, 85... it displays 100, 95, 89, 84, 79...
That is because it is rounding down. Rounding up with ceill() instead of floor() fixes the problem.