### PR TITLE
Osx compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Now if you want curl, make sure you have curl libs 7.57 or newer installed (note
  make STATIC=0
 ```
 
+## for osx (m1 or x86)
+
+
+```
+make STATIC=0 NOCURL=1
+```
 
 
 # usage example:

--- a/gcodestat.c
+++ b/gcodestat.c
@@ -22,7 +22,9 @@
 #include <string.h>
 #include <stdbool.h>
 #include <math.h>
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
 #include <sys/time.h>
 
 #ifndef NOCURL


### PR DESCRIPTION
hello, modified to exclude malloc.h for osx compiling, I changed also the compile istructions, as you suggested in my past pull request.  Compiled tested on M1 mac and X86.